### PR TITLE
Copying a small chapter or if the terminal window is too small

### DIFF
--- a/vobcopy.c
+++ b/vobcopy.c
@@ -2218,6 +2218,18 @@ int makedir( char *name )
 }
 
 /*
+ * Get the width in characters of the terminal window, or defaults to 80.
+ */
+int get_term_width() {
+   struct winsize ws;
+   if (ioctl(1, TIOCGWINSZ, &ws) >= 0)
+      return ws.ws_col;
+   else
+      return 80;
+}
+
+
+/*
 * Check the time determine whether a new progress line should be output (once per second)
 */
 
@@ -2230,22 +2242,20 @@ int progressUpdate(int starttime, int cur, int tot, int force)
 	  int barLen, barChar, numChars, timeSoFar, minsLeft, secsLeft, ctr, cols;
 	  float percentComplete, percentLeft, timePerPercent;
 	  int curtime, timeLeft;
-	  struct winsize ws; 
 
-	  ioctl(0, TIOCGWINSZ, &ws);
-	  cols = ws.ws_col - 1;
+	  cols = get_term_width();
 
 	  progress_time = time(NULL);
 	  curtime = time(NULL);
 
 	  printf("\r");
 /* 	   calc it this way so it's easy to change later */
-/* 	   2 for brackets, 1 for space, 5 for percent complete, 1 for space, 6 for time left, 1 for space */
-	  barLen = cols - 2 - 1 - 5 - 1 - 6 - 1;
+/* 	   2 for brackets, 1 for space, 5 for percent complete, 1 for space, 6 for time left, 1 for space, 1 for padding */
+	  barLen = cols - 2 - 1 - 5 - 1 - 6 - 1 - 1;
 	  barChar = tot / barLen;
 	  percentComplete = (float)((float)cur / (float)tot * 100.0);
 	  percentLeft = 100 - percentComplete;
-	  numChars = cur / barChar;
+	  numChars = (barChar <= 0) ? 0 : cur / barChar;
 
 /* 	   guess remaining time */
 	  timeSoFar = curtime - starttime;


### PR DESCRIPTION
Then printing the progress bar results in a divide by zero and the track cannot be copied. 
