### PR TITLE
Fix null dereference crash resulting from vobcopy -I

### DIFF
--- a/vobcopy.c
+++ b/vobcopy.c
@@ -1439,7 +1439,7 @@ next: /*for the goto - ugly, I know... */
       fprintf( stderr, _("[Info]  Disk free: %f MB\n"), (double)  (pwd_free / ( 1024.0*1024.0 )) );
       fprintf( stderr, _("[Info]  Vobs size: %f MB\n"), (double)  vob_size / ( 1024.0*1024.0 ) );
       ifoClose( vmg_file );
-      DVDCloseFile( dvd_file );
+      if(dvd_file) DVDCloseFile( dvd_file );
       DVDClose( dvd );
       /*hope all are closed now...*/
       exit( 0 );


### PR DESCRIPTION
I found a null dereference on exit after running `vobcopy -I`. This is the fix for that bug.