### PR TITLE
fix null dereference when using iso disk image

### DIFF
--- a/dvd.c
+++ b/dvd.c
@@ -258,8 +258,6 @@ this is the code for the other-OSs, not solaris*/
 		mounted = TRUE;
 		break;
 	    }
-	}
-	endmntent(tmp_streamin);
         
         if (strcmp(lmount_entry->mnt_fsname, "fuseiso") == 0) {
           fprintf ( stderr, "[Info] Fuseiso detected. I'm looking for the iso file\n");
@@ -283,6 +281,8 @@ this is the code for the other-OSs, not solaris*/
             endmntent(tmp_streamin_fuseiso);
           }
         }
+	}
+	endmntent(tmp_streamin);
 
 	if (mounted) 
             {


### PR DESCRIPTION
Found a null dereference when using an image file instead of an actual drive.
This seems to have been caused by a chunk from 7934e105 being added two lines too low, causing the code to wait for `lmount_entry` to be null before trying to dereference it.